### PR TITLE
feat: impl Iterator<Item=u64> for Stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ default = ["std","alloc","utf8-ranges","levenshtein"]
 levenshtein = ["utf8-ranges", "alloc"]
 std = ["alloc"]
 alloc = []
+# If enabled, `Iterator<Item=u64> will be impled for Stream`
+stream-iter = []
 
 [dependencies]
 utf8-ranges = { version = "1.0.4", optional = true }

--- a/src/set.rs
+++ b/src/set.rs
@@ -694,7 +694,7 @@ impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
     type Item = &'a [u8];
 
     fn next(&'a mut self) -> Option<&'a [u8]> {
-        self.0.next().map(|(key, _)| key)
+        Streamer::next(&mut self.0).map(|(key, _)| key)
     }
 }
 


### PR DESCRIPTION
### What does this PR do

implement `Iterator<Item=u64>` for `fst_no_std::map::Stream`, the returned `u64` comes from `Streamer::next(&mut stream).map(|(_, output)| output.value())`.